### PR TITLE
add host entry to access host machine within docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ runner:
       - token=${token}
       - name=${name}
       - workdir=/actionsRunnerWorkdir/${name}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /actionsRunnerWorkdir/${name}:/actionsRunnerWorkdir/${name}
 ```
-To work properly the runner needs a volume which has the same path on the host and the container.
+To work properly the runner needs a volume which has the same path on the host and the container. \
+The host entry sets a possiblility to reach the host with the url `host.docker.internal` to for example access a startet docker container.
 
 An example `.env` file has the following content:
 ```sh

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -11,6 +11,8 @@ services:
       - token=${token}
       - name=${name1}
       - workdir=/actionsRunnerWorkdir/${name1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /actionsRunnerWorkdir/${name1}:/actionsRunnerWorkdir/${name1}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,8 @@ services:
       - token=${token}
       - name=${name1}
       - workdir=/actionsRunnerWorkdir/${name1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /actionsRunnerWorkdir/${name1}:/actionsRunnerWorkdir/${name1}
@@ -26,6 +28,8 @@ services:
       - token=${token}
       - name=${name2}
       - workdir=/actionsRunnerWorkdir/${name2}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /actionsRunnerWorkdir/${name2}:/actionsRunnerWorkdir/${name2}
@@ -40,6 +44,8 @@ services:
       - token=${token}
       - name=${name3}
       - workdir=/actionsRunnerWorkdir/${name3}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /actionsRunnerWorkdir/${name3}:/actionsRunnerWorkdir/${name3}
@@ -54,6 +60,8 @@ services:
       - token=${token}
       - name=${name4}
       - workdir=/actionsRunnerWorkdir/${name4}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /actionsRunnerWorkdir/${name4}:/actionsRunnerWorkdir/${name4}


### PR DESCRIPTION
Container started in actions can be accessed via `host.docker.internal` after merging. 
This is necessary cause localhost points to the actions-runner container but the started containers run on the host machine.

This is a follow up of Gamify-IT/issues#119